### PR TITLE
update requirements.txt to avoid CVE-2017-18342

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ click~=6.7
 nbformat~=4.4
 nbconvert~=5.3
 civis~=1.6
-pyyaml~=3.12
+pyyaml
 python-dateutil~=2.6
 ipython~=5.4 ; python_version >= '2.7' and python_version < '3.0'
 ipython~=6.2 ; python_version >= '3.0'


### PR DESCRIPTION
This PR addresses vulnerabilities High Severity issues w/ pyyaml by removing the version pinning on pyyaml. 

Must find if this is deployed anywhere and update it. 

--timball